### PR TITLE
Fixed capitalization in duedate

### DIFF
--- a/event.unencoded.items.json
+++ b/event.unencoded.items.json
@@ -18,7 +18,7 @@
       "status": {
         "code": "-",
         "display": "Available",
-        "dueDate": null
+        "duedate": null
       },
       "barcode": "32101062243553",
       "callNumber": "PJ7601",

--- a/lib/serializers/item.js
+++ b/lib/serializers/item.js
@@ -152,8 +152,8 @@ var fromMarcJson = (object, datasource) => {
     if (object.status && object.status.code && object.status.code.trim()) {
       status = { path: 'status' }
       if (object.status.code === '-') {
-        // Code '-' matches both Available and Loaned (!!!) so, check dueDate
-        status.id = object.status.dueDate ? 'co' : 'a'
+        // Code '-' matches both Available and Loaned (!!!) so, check duedate
+        status.id = object.status.duedate ? 'co' : 'a'
       } else {
         status.code = object.status.code
       }

--- a/test/data/item-10003973.json
+++ b/test/data/item-10003973.json
@@ -16,7 +16,7 @@
   "status": {
     "code": "-",
     "display": "AVAILABLE",
-    "dueDate": null
+    "duedate": null
   },
   "barcode": "33433107664710",
   "callNumber": "|h*Z-3527 R. 2A",

--- a/test/data/item-10781594.json
+++ b/test/data/item-10781594.json
@@ -16,7 +16,7 @@
   "status": {
     "code": "-",
     "display": "AVAILABLE",
-    "dueDate": null
+    "duedate": null
   },
   "barcode": "33433007725926",
   "callNumber": "|hTPB (International Railway Congress. (VII) Washington, 1905. Summary of proceedings)",

--- a/test/data/item-pul-189241.json
+++ b/test/data/item-pul-189241.json
@@ -16,7 +16,7 @@
   "status": {
     "code": "-",
     "display": "Available",
-    "dueDate": null
+    "duedate": null
   },
   "barcode": "32101062243553",
   "callNumber": "PJ7601",


### PR DESCRIPTION
Apparently, `duedate` is returned from the Sierra API in all lowercase. I, incorrectly, had it set as camelcase (i.e. `dueDate`).

I fixed it upstream (and all the corresponding schemas) but this PR is necessary to fix the serializer logic.

This also means, we've never serialized any items correctly using this logic. 😬 