### PR TITLE
Fix bug due to relying on stream ARNs

### DIFF
--- a/event.json
+++ b/event.json
@@ -14,7 +14,7 @@
       "eventName": "aws:kinesis:record",
       "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
       "awsRegion": "us-east-1",
-      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/Bib"
+      "eventSourceARN": "the-first-part-of-the-arn-does-not-matter...this-part-does:/Bib"
     }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var log = null
 const BibsUpdater = require('./lib/bibs-updater')
 const ItemsUpdater = require('./lib/items-updater')
 const avro = require('avsc')
-const config = require('config')
 const db = require('./lib/db')
 const kmsHelper = require('./lib/kms-helper')
 const NYPLDataApiClient = require('@nypl/nypl-data-api-client')
@@ -41,7 +40,14 @@ function getSchema (schemaName) {
 }
 
 function processEvent (event, context, callback) {
-  let bibOrItem = event.Records[0].eventSourceARN === config.kinesisReadStreams.bib ? 'Bib' : 'Item'
+  let bibOrItem = null
+
+  // Determine whether event has Bibs or Items by checking end of eventSourceARN string:
+  if (/\/Bib$/.test(event.Records[0].eventSourceARN)) bibOrItem = 'Bib'
+  if (/\/Item$/.test(event.Records[0].eventSourceARN)) bibOrItem = 'Item'
+
+  // Fail if the eventSourceARN didn't tell us what we're handling
+  if (!bibOrItem) throw new Error('Unrecognized eventSourceARN. Aborting. ' + event.Records[0].eventSourceARN)
 
   log.debug('Using schema: ', bibOrItem)
   // db.connect().then(() => getSchema(bibOrItem)).then((schemaType) => {

--- a/index.js
+++ b/index.js
@@ -43,8 +43,8 @@ function processEvent (event, context, callback) {
   let bibOrItem = null
 
   // Determine whether event has Bibs or Items by checking end of eventSourceARN string:
-  if (/\/Bib$/.test(event.Records[0].eventSourceARN)) bibOrItem = 'Bib'
-  if (/\/Item$/.test(event.Records[0].eventSourceARN)) bibOrItem = 'Item'
+  if (/\/Bib/.test(event.Records[0].eventSourceARN)) bibOrItem = 'Bib'
+  if (/\/Item/.test(event.Records[0].eventSourceARN)) bibOrItem = 'Item'
 
   // Fail if the eventSourceARN didn't tell us what we're handling
   if (!bibOrItem) throw new Error('Unrecognized eventSourceARN. Aborting. ' + event.Records[0].eventSourceARN)


### PR DESCRIPTION
This PR:
 - Revises handler logic to check only the *end* of the eventSourceARN to determine whether to decode a Bib or Item (rather than depend on configured stream ARNs)
 - Updates kinesify-data accordingly, applying a fake eventSourceARN that satisfies the handler's expectation that the ARN end in either /Bib or /Item
 - Makes the 4th param to kinesify-data (schemaUrl) truly optional by deriving it from the record's `nyplType` when not explicitly given