### PR TITLE
Fix: missing support for stream name config to items updater

### DIFF
--- a/lib/bibs-updater.js
+++ b/lib/bibs-updater.js
@@ -211,7 +211,6 @@ class BibsUpdater {
       return this.streamsClient.write(streamName, recs, { avroSchemaName: schemaName })
         .then(() => {
           log.debug(`Wrote ${recs.length} to ${streamName} (encoded against ${schemaName})`)
-          console.log(`Wrote ${recs.length} record(s) to ${streamName} (encoded against ${schemaName})`)
         })
         .then(() => batch)
     } else return Promise.resolve(batch)

--- a/lib/items-updater.js
+++ b/lib/items-updater.js
@@ -27,6 +27,10 @@ var itemsSource = SourceLoader.load(config.get('itemsSource'))
 const CACHE_TO_DISK = false
 
 class ItemsUpdater {
+  constructor () {
+    this.streamsClient = new NyplStreamsClient({ nyplDataApiClientBase: process.env['NYPL_API_BASE_URL'], logLevel: 'error' })
+  }
+
   deserialize (buffered, avro) {
     var item = {}
 
@@ -122,7 +126,7 @@ class ItemsUpdater {
           log.info(`ItemsUpdater#update: Saved batch of ${num} (${statements.length} statements): (${totalProcessed} total processed, index ${totalProcessed + options.offset})`)
           return statements
         })
-        .map(this._writeToIndexDocumentQueue) // Write to IndexDocumentQueue stream
+        .map((batch) => this._writeToIndexDocumentQueue(batch)) // Write to IndexDocumentQueue stream
         .flatMap((r) => H(r))
         .stopOnError((e) => reject(this.handleError(e, '...')))
         .done(function (err) {
@@ -139,22 +143,28 @@ class ItemsUpdater {
 
   // Takes a batch of inserted records, writes to IndexDocument stream
   _writeToIndexDocumentQueue (batch) {
-    // Get distinct bib ids by grabbing distinct objectIds from the known nypl:bnum pred
-    var distinctBibIds = Object.keys(
-      batch
-        .filter((s) => s.predicate === 'nypl:bnum')
-        .map((s) => s.object_id.replace('urn:bnum:', ''))
-        .reduce((h, bnum) => {
-          h[bnum] = true
-          return h
-        }, {})
-    )
-    // Submit bib ids to write stream:
-    if (distinctBibIds.length && config.kinesisWriteStream) {
+    let streamName = process.env.INDEX_DOCUMENT_STREAM_NAME
+    let schemaName = process.env.INDEX_DOCUMENT_SCHEMA_NAME
+    // Make sure stream-writing is configured
+    if (streamName && schemaName) {
+      // Get distinct bib ids by grabbing distinct objectIds from the known nypl:bnum pred
+      var distinctBibIds = Object.keys(
+        batch
+          .filter((s) => s.predicate === 'nypl:bnum')
+          .map((s) => s.object_id.replace('urn:bnum:', ''))
+          .reduce((h, bnum) => {
+            h[bnum] = true
+            return h
+          }, {})
+      )
+      // Submit bib ids to write stream:
       var recs = distinctBibIds.map((uri) => {
         return { type: 'record', uri }
       })
-      return (new NyplStreamsClient({ nyplDataApiClientBase: process.env['NYPL_API_BASE_URL'] })).write(config.kinesisWriteStream.stream, recs)
+      return this.streamsClient.write(streamName, recs, { avroSchemaName: schemaName })
+        .then(() => {
+          log.debug(`Wrote ${recs.length} to ${streamName} (encoded against ${schemaName})`)
+        })
         .then(() => batch)
     } else return Promise.resolve(batch)
   }


### PR DESCRIPTION
This is a hot fix to correct a bug observed during bulk load where IndexDocumentQueue-production is not written to by doing the following:

 - the "output" stream (previously "IndexDocumentQueue") was previously configured via config. Now that 1) it's configured via ENV, and 2) it's potentially different from the schema name, this update ensures the items-updater lib draws on the right config (mimicking a similar update made to the bibs-updater)
 - rm rogue console.log