### PR TITLE
nypl-core-objects fixes & related

### DIFF
--- a/lib/items-updater.js
+++ b/lib/items-updater.js
@@ -104,6 +104,8 @@ class ItemsUpdater {
         })
         .map((item) => this.extractStatements(item).then((statements) => ({ statements, item })))
         .flatMap((r) => H(r))
+        // Ensure serializer extracted some statements:
+        .filter((s) => s.statements && s.statements.length > 0)
         .map((stmts) => {
           log.debug(`Got ${stmts.statements ? stmts.statements.length : 'null'} statements for ${stmts.item.id}`)
           return stmts

--- a/lib/models/item-sierra-record.js
+++ b/lib/models/item-sierra-record.js
@@ -3,8 +3,6 @@
 const sierraLocationMapping = require('@nypl/nypl-core-objects')('by-sierra-location')
 const SierraRecord = require('./sierra-record')
 
-// console.log('sierra record class: ', SierraRecord)
-
 class ItemSierraRecord extends SierraRecord {
   prefixedId () {
     var prefix = ''

--- a/lib/serializers/item.js
+++ b/lib/serializers/item.js
@@ -1,6 +1,6 @@
 const sierraLocationMapping = require('@nypl/nypl-core-objects')('by-sierra-location')
 const organizationMapping = require('@nypl/nypl-core-objects')('by-organizations')
-const accessMessageMapping = require('@nypl/nypl-core-objects')('by-accessmessages')
+const accessMessageMapping = require('@nypl/nypl-core-objects')('by-accessMessages')
 const statusMapping = require('@nypl/nypl-core-objects')('by-statuses')
 const catalogItemTypeMapping = require('@nypl/nypl-core-objects')('by-catalog-item-types')
 
@@ -39,7 +39,11 @@ var fromElectronicItem = (object, datasource) => {
 
 var fromMarcJson = (object, datasource) => {
   if (!datasource) datasource = Datasource.byMarcJsonNyplSource(object.nyplSource)
-  if (!datasource) throw new Error('No datasource given')
+  if (!datasource) {
+    // If nyplSource is 'test', fail quietly:
+    if (object.nyplSource === 'test') return Promise.resolve(null)
+    else throw new Error('Unable to parse datasource from nyplSource ' + object.nyplSource)
+  }
 
   try {
     var fieldMapper = buildFieldMapper('item', object.nyplSource)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "NYPL Discovery",
   "dependencies": {
-    "@nypl/nypl-core-objects": "^1.1.7",
+    "@nypl/nypl-core-objects": "^1.1.8",
     "@nypl/nypl-data-api-client": "^0.2.5",
     "@nypl/nypl-streams-client": "^0.1.4",
     "avro-js": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "NYPL Discovery",
   "dependencies": {
     "@nypl/nypl-core-objects": "^1.1.7",
-    "@nypl/nypl-data-api-client": "^0.2.0",
+    "@nypl/nypl-data-api-client": "^0.2.5",
     "@nypl/nypl-streams-client": "^0.1.4",
     "avro-js": "^1.8.0",
     "avro-parser": "^1.0.1",

--- a/test/item-marc-test.js
+++ b/test/item-marc-test.js
@@ -57,7 +57,7 @@ describe('Item Marc Mapping', function () {
           assert.equal(item.objectId('nypl:holdingLocation'), 'loc:rcma2')
           assert.equal(item.objectId('nypl:catalogItemType'), 'catalogItemType:55')
           assert.equal(item.objectId('nypl:accessMessage'), 'accessMessage:2')
-          assert.equal(item.statement('nypl:accessMessage').object_label, 'ADV REQUEST')
+          assert.equal(item.statement('nypl:accessMessage').object_label, 'Request in advance')
         })
     })
   })


### PR DESCRIPTION
This PR:

 - Ensures messages received in `Items` stream that have nyplSource 'test' are quietly ignored so that future (and current?) stream records with that value do not prevent other things in the stream from being processed
 - Update item-marc test so updated accessmessage (from nypl-core) is expected
 - Update call to `require('@nypl/nypl-core-objects')('by-accessmessages')` to match updated case
 - Bumps nypl-core-objects & nypl-data-api-client to latest