### PR TITLE
Add new note suppression rule SRCH-298

### DIFF
--- a/lib/bibs-updater.js
+++ b/lib/bibs-updater.js
@@ -149,7 +149,7 @@ class BibsUpdater extends UpdaterBase {
           throw new Error('Error updating database; assume connection error')
         }))
         .flatMap((r) => H(r))
-        .map((statements) => db.deleteStaleStatements('resource', statements).then(() => statements)) // Delete extra (previously serialized) statements
+        .map((statements) => db.deleteStaleStatements('resource', statements, 'bib').then(() => statements)) // Delete extra (previously serialized) statements
         .flatMap((r) => H(r))
         .map((statements) => {
           log.debug('Statements: ', statements)

--- a/lib/db.js
+++ b/lib/db.js
@@ -259,10 +259,17 @@ var deleteStatements = (tableName, match) => {
 
 /*
  *  Special delete call to trim extra lingering statements left over from previous serializations.
- *  Given an array of statements (assumed to be same creator)
- *  This function will delete from the database any statements that exceed the index for each subject-predicate pair
+ *
+ *  Given an array of statements (assumed to be same creator)..
+ *  this function will delete from the database any old statements identified by
+ *   - having an index that exceeds the max index presently being saved
+ *   - having a predicate not among those presently being saved
+ *
+ *  @param {string} tableName Name of table, e.g. 'resource_statement'
+ *  @param {array} statements Array of plain objects representing statements to save
+ *  @param {string} type String identifying type of resource (bib/item), which is used to identify un-saved predicates
   */
-var deleteStaleStatements = (tableName, statements) => {
+var deleteStaleStatements = (tableName, statements, type) => {
   if (!statements || statements.length === 0) return Promise.resolve()
 
   var creator_id = statements[0].creator_id
@@ -273,12 +280,25 @@ var deleteStaleStatements = (tableName, statements) => {
   // For each subject..
   var subjectMatches = Object.keys(subjectsMappedToPredicatesMappedToOffsets).map((subject_id) => {
     // Group distinct indexes
-    var distinctIndexes = Object.keys(subjectsMappedToPredicatesMappedToOffsets[subject_id]).reduce((h, predicate) => {
+    let predicates = Object.keys(subjectsMappedToPredicatesMappedToOffsets[subject_id])
+    var distinctIndexes = predicates.reduce((h, predicate) => {
       var index = subjectsMappedToPredicatesMappedToOffsets[subject_id][predicate]
       if (!h[index]) h[index] = []
       h[index].push(predicate)
       return h
     }, {})
+
+    // We now have a map that maps max-index values to an array of predicates
+    //
+    // e.g. distinctIndexes[0] => ['dcterms:title', 'nypl:suppressed', 'dc:contributor']
+    // .. Which means, for example, the maximum `index` of any 'dcterms:title' statement we're saving is 0
+    // .. Which means we want to delete any 'dcterms:title' with `index` > 0 (because it's old)
+
+    // We also want to issue a DELETE on any old predicates we may have saved for this subject in the past:
+    // By setting max-index to -1, we effectively delete all statements with these
+    // predicates (because all statements have index 0..N)
+    distinctIndexes[-1] = unusedPredicates(predicates, type)
+
     // Get predicate-index specific clauses:
     var predIndexClauses = Object.keys(distinctIndexes).map((index) => {
       var preds = distinctIndexes[index]
@@ -323,6 +343,24 @@ var groupStatementsBySubjectPredicateAndMaxIndex = (statements) => {
     return grouped
   }, {})
   return grouped
+}
+
+/*
+ * Get array of predicates not represented by statements based on known predicates mapped for type.
+ *
+ * @param {array} usedPredicates Array of predicate strings being used
+ * @param {string} type Either 'bib' or 'item'
+ *
+ * This is useful for identifying what is missing from:
+ *   1) the world of all predicates we ever save for a subject and
+ *   2) the predicates we're presently saving for one (usedPredicates)
+ *
+ * What remains is the set of predicates we are *not* currently saving,
+ * which identify statements about this subject that we may wish to delete.
+ */
+var unusedPredicates = (usedPredicates, type) => {
+  let allPredicates = require('./field-mapper')(type).allPredicates()
+  return allPredicates.filter((predicate) => usedPredicates.indexOf(predicate) < 0)
 }
 
 const ENTITY_TYPES = ['resource']

--- a/lib/field-mapper.js
+++ b/lib/field-mapper.js
@@ -21,6 +21,17 @@ class FieldMapper {
     var spec = this.getMapping(field)
     return spec.pred
   }
+
+  allPredicates () {
+    // Get all referenced predicates:
+    let preds = Object.keys(this.data)
+      .map((fieldLabel) => this.predicateFor(fieldLabel))
+    // Unique them:
+    return Object.keys(preds.reduce((h, p) => {
+      h[p] = true
+      return h
+    }, {}))
+  }
 }
 
 // Syncronously fetch url, caching it for subsequent "requires"

--- a/lib/items-updater.js
+++ b/lib/items-updater.js
@@ -110,7 +110,7 @@ class ItemsUpdater extends UpdaterBase {
         .reduce([], (memo, batch) => memo.concat(batch.statements)) // Flatten array
         .map((statements) => db.upsertStatements('resource', statements).then(() => statements)) // Save statements
         .flatMap((r) => H(r))
-        .map((statements) => db.deleteStaleStatements('resource', statements).then(() => statements)) // Delete extra (previously serialized) statements
+        .map((statements) => db.deleteStaleStatements('resource', statements, 'item').then(() => statements)) // Delete extra (previously serialized) statements
         .flatMap((r) => H(r))
         .map((statements) => {
           // Report on success

--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -310,7 +310,7 @@ var fromMarcJson = (object, datasource) => {
         if (builder.get('bf:issuance') && ['urn:biblevel:c', 'urn:biblevel:s'].indexOf(builder.get('bf:issuance').object_id) >= 0) {
           type = 'nypl:Collection'
         }
-        builder.add('rdf:type', { id: type }, 0)
+        builder.add(fieldMapper.predicateFor('Type'), { id: type }, 0)
 
         return builder.statements
       })

--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -210,8 +210,8 @@ var fromMarcJson = (object, datasource) => {
     noteMapping.paths.forEach((path) => {
       // Extract value by marc & subfields
       var val = object.varField(path.marc, path.subfields, { preFilter: (block) => {
-        // Notes extracted from 541 and 561 should be suppressed if ind1 is '0'
-        return ['541', '561'].indexOf(block.marcTag) < 0 || block.ind1 !== '0'
+        // Notes should be suppressed if ind1 is '0'
+        return block.ind1 !== '0'
       }})
 
       // Build provo path

--- a/lib/serializers/item.js
+++ b/lib/serializers/item.js
@@ -51,7 +51,7 @@ var fromMarcJson = (object, datasource) => {
 
     var builder = Statement.builder(id, Creator.CORE_SERIALIZER.id, { id: datasource.id, record_id: object.id })
 
-    builder.add('rdf:type', { id: 'bf:Item' })
+    builder.add('rdfs:type', { id: 'bf:Item' })
 
     // Bnumber identifier
     utils.compact(utils.flattenArray(object.bibIds)).forEach((bibId, ind) => {

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -74,7 +74,7 @@ describe('Bib Marc Mapping', function () {
         .then((bib) => {
           // console.log('bib: ', bib)
 
-          assert.equal(bib.objectId('rdf:type'), 'nypl:Item')
+          assert.equal(bib.objectId('rdfs:type'), 'nypl:Item')
           assert.equal(bib.objectId('dcterms:type'), 'resourcetypes:txt')
 
           assert.equal(bib.objectId('bf:issuance'), 'urn:biblevel:m')
@@ -185,8 +185,8 @@ describe('Bib Marc Mapping', function () {
           // Confirm issuance marks it as a serial:
           assert.equal(bib.objectId('bf:issuance'), 'urn:biblevel:s')
 
-          // Serials are rdf:type Collection:
-          assert.equal(bib.objectId('rdf:type'), 'nypl:Collection')
+          // Serials are rdfs:type Collection:
+          assert.equal(bib.objectId('rdfs:type'), 'nypl:Collection')
         })
     })
 
@@ -199,8 +199,8 @@ describe('Bib Marc Mapping', function () {
           // Confirm issuance marks it as a collection:
           assert.equal(bib.objectId('bf:issuance'), 'urn:biblevel:c')
 
-          // Serials are rdf:type Collection:
-          assert.equal(bib.objectId('rdf:type'), 'nypl:Collection')
+          // Serials are rdfs:type Collection:
+          assert.equal(bib.objectId('rdfs:type'), 'nypl:Collection')
 
           // Material Type is 'h' and has 007/00-01 == hd, so so carrier type should be hd
           assert.equal(bib.objectId('bf:carrier'), 'carriertypes:hd')
@@ -399,7 +399,7 @@ describe('Bib Marc Mapping', function () {
         .then((bib) => {
           assert.equal(bib.id, 'pb176961')
           // TODO need to check a whole bunch more fields...
-          assert.equal(bib.objectId('rdf:type'), 'nypl:Item')
+          assert.equal(bib.objectId('rdfs:type'), 'nypl:Item')
           assert.equal(bib.objectId('bf:media'), 'mediatypes:n')
           assert.equal(bib.objectId('bf:carrier'), 'carriertypes:nc')
           // Extracted ISBN?

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -379,6 +379,18 @@ describe('Bib Marc Mapping', function () {
         })
     })
 
+    it('should not serialize hidden notes', function () {
+      var bib = BibSierraRecord.from(require('./data/bib-10070948.json'))
+
+      return bibSerializer.fromMarcJson(bib)
+        .then((statements) => new Bib(statements))
+        .then((bib) => {
+          // This bib has one note in 505, but ind1 === 0, so it should be suppressed
+          // which means it has NO notes.
+          assert.equal(bib.literals('skos:note').length, 0)
+        })
+    })
+
     it('should assign correct PUL fields', function () {
       var bib = BibSierraRecord.from(require('./data/bib-pul-176961.json'))
 

--- a/test/data/bib-10070948.json
+++ b/test/data/bib-10070948.json
@@ -1,0 +1,438 @@
+{
+  "id": "10070948",
+  "nyplSource": "sierra-nypl",
+  "nyplType": "bib",
+  "updatedDate": "2012-01-09T16:47:09Z",
+  "createdDate": "2008-12-13T16:59:56Z",
+  "deletedDate": null,
+  "deleted": false,
+  "locations": null,
+  "suppressed": false,
+  "lang": {
+    "code": "0",
+    "name": "English"
+  },
+  "title": "Soul clap hands and sing.",
+  "author": "Marshall, Paule, 1929-",
+  "materialType": {
+    "code": "a",
+    "value": "BOOK/TEXT"
+  },
+  "bibLevel": {
+    "code": "m",
+    "value": "MONOGRAPH"
+  },
+  "publishYear": 1971,
+  "catalogDate": "2000-10-03",
+  "country": {
+    "code": "0",
+    "name": "New Jersey"
+  },
+  "normTitle": null,
+  "normAuthor": null,
+  "fixedFields": [
+    {
+      "label": "Language",
+      "value": "eng",
+      "display": "English"
+    },
+    {
+      "label": "Skip",
+      "value": "0",
+      "display": "0"
+    },
+    {
+      "label": "Location",
+      "value": "mal  ",
+      "display": "Schwarzman Building - Service Desk Rm 217"
+    },
+    {
+      "label": "COPIES",
+      "value": "1",
+      "display": "1"
+    },
+    {
+      "label": "Cat. Date",
+      "value": "2000-10-03",
+      "display": "2000-10-03"
+    },
+    {
+      "label": "Bib Level",
+      "value": "m",
+      "display": "MONOGRAPH"
+    },
+    {
+      "label": "Material Type",
+      "value": "a",
+      "display": "BOOK/TEXT"
+    },
+    {
+      "label": "Bib Code 3",
+      "value": "-",
+      "display": "-"
+    },
+    {
+      "label": "Record Type",
+      "value": "b",
+      "display": "b"
+    },
+    {
+      "label": "Record Number",
+      "value": "10070948",
+      "display": "10070948"
+    },
+    {
+      "label": "Created Date",
+      "value": "2008-12-13T16:59:56Z",
+      "display": "2008-12-13T16:59:56Z"
+    },
+    {
+      "label": "Updated Date",
+      "value": "2012-01-09T16:47:09Z",
+      "display": "2012-01-09T16:47:09Z"
+    },
+    {
+      "label": "No. of Revisions",
+      "value": "5",
+      "display": "5"
+    },
+    {
+      "label": "Agency",
+      "value": "1",
+      "display": "1"
+    },
+    {
+      "label": "Country",
+      "value": "nju",
+      "display": "New Jersey"
+    },
+    {
+      "label": "PDATE",
+      "value": "2012-01-06T18:23:08Z",
+      "display": "2012-01-06T18:23:08Z"
+    },
+    {
+      "label": "MARC Type",
+      "value": " ",
+      "display": " "
+    }
+  ],
+  "varFields": [
+    {
+      "fieldTag": "a",
+      "marcTag": "100",
+      "ind1": "1",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": "Marshall, Paule,"
+        },
+        {
+          "tag": "d",
+          "content": "1929-"
+        }
+      ]
+    },
+    {
+      "fieldTag": "i",
+      "marcTag": "020",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": "0911860061"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "010",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": "78170921"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": "NN724103130"
+        }
+      ]
+    },
+    {
+      "fieldTag": "l",
+      "marcTag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": "(WaOLN)nyp0071196"
+        }
+      ]
+    },
+    {
+      "fieldTag": "n",
+      "marcTag": "505",
+      "ind1": "0",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": "Barbados.--Brooklyn.--British Guiana.--Brazil."
+        }
+      ]
+    },
+    {
+      "fieldTag": "o",
+      "marcTag": "001",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "NYPG724103130-B",
+      "subFields": null
+    },
+    {
+      "fieldTag": "p",
+      "marcTag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": "Chatham, N.J.,"
+        },
+        {
+          "tag": "b",
+          "content": "Chatham Bookseller"
+        },
+        {
+          "tag": "c",
+          "content": "[1971, c1961]"
+        }
+      ]
+    },
+    {
+      "fieldTag": "q",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "h",
+          "content": "JFD 72-6746"
+        }
+      ]
+    },
+    {
+      "fieldTag": "r",
+      "marcTag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": "177 p."
+        },
+        {
+          "tag": "c",
+          "content": "21 cm."
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": "245",
+      "ind1": "1",
+      "ind2": "0",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": "Soul clap hands and sing."
+        }
+      ]
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": "959",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": ".b10718874"
+        },
+        {
+          "tag": "b",
+          "content": "07-18-08"
+        },
+        {
+          "tag": "c",
+          "content": "07-30-91"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "005",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "20000629165556.0",
+      "subFields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "008",
+      "ind1": " ",
+      "ind2": " ",
+      "content": "720911c19711961nju           00| 1|eng| cam   ",
+      "subFields": null
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "040",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "c",
+          "content": "NN"
+        },
+        {
+          "tag": "d",
+          "content": "NN"
+        },
+        {
+          "tag": "d",
+          "content": "WaOLN"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "050",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": "PZ4.M369"
+        },
+        {
+          "tag": "b",
+          "content": "So4"
+        },
+        {
+          "tag": "a",
+          "content": "PS3563.A7223"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "908",
+      "ind1": " ",
+      "ind2": "0",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": "PZ4.M369"
+        },
+        {
+          "tag": "b",
+          "content": "So4"
+        },
+        {
+          "tag": "a",
+          "content": "PS3563.A7223"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "997",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "a",
+          "content": "hg"
+        },
+        {
+          "tag": "b",
+          "content": "10-03-00"
+        },
+        {
+          "tag": "c",
+          "content": "m"
+        },
+        {
+          "tag": "d",
+          "content": "a"
+        },
+        {
+          "tag": "e",
+          "content": "-"
+        },
+        {
+          "tag": "f",
+          "content": "eng"
+        },
+        {
+          "tag": "g",
+          "content": "nju"
+        },
+        {
+          "tag": "h",
+          "content": "0"
+        }
+      ]
+    },
+    {
+      "fieldTag": "y",
+      "marcTag": "991",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subFields": [
+        {
+          "tag": "y",
+          "content": "222327"
+        }
+      ]
+    },
+    {
+      "fieldTag": "_",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "00000cam  2200229   4500",
+      "subFields": null
+    }
+  ]
+}

--- a/test/data/item-23937039.json
+++ b/test/data/item-23937039.json
@@ -1,0 +1,316 @@
+{
+  "nyplSource": "sierra-nypl",
+  "bibIds": [
+    "17664294"
+  ],
+  "id": "23937039",
+  "nyplType": "item",
+  "updatedDate": "2017-09-08T19:57:49-04:00",
+  "createdDate": "2009-06-20T14:13:42-04:00",
+  "deletedDate": null,
+  "deleted": false,
+  "location": {
+    "code": "rcpr2",
+    "name": "OFFSITE - Request in Advance for use at Performing Arts"
+  },
+  "status": {
+    "code": "-",
+    "display": "AVAILABLE",
+    "duedate": null
+  },
+  "barcode": "33433081307138",
+  "callNumber": null,
+  "itemType": null,
+  "fixedFields": {
+    "57": {
+      "label": "BIB HOLD",
+      "value": false,
+      "display": null
+    },
+    "58": {
+      "label": "Copy No.",
+      "value": 1,
+      "display": null
+    },
+    "59": {
+      "label": "Item Code 1",
+      "value": "0",
+      "display": null
+    },
+    "60": {
+      "label": "Item Code 2",
+      "value": "-",
+      "display": null
+    },
+    "61": {
+      "label": "Item Type",
+      "value": "132",
+      "display": "RFVC - FILM"
+    },
+    "62": {
+      "label": "Price",
+      "value": 60000,
+      "display": null
+    },
+    "64": {
+      "label": "Checkout Location",
+      "value": 84,
+      "display": null
+    },
+    "68": {
+      "label": "Last Checkin",
+      "value": "2015-06-11T21:00:34Z",
+      "display": null
+    },
+    "69": {
+      "label": "Inventory Date",
+      "value": "2017-05-08T08:00:00Z",
+      "display": null
+    },
+    "70": {
+      "label": "Checkin Location",
+      "value": 84,
+      "display": null
+    },
+    "74": {
+      "label": "Item Use 3",
+      "value": 0,
+      "display": null
+    },
+    "76": {
+      "label": "Total Checkouts",
+      "value": 7,
+      "display": null
+    },
+    "77": {
+      "label": "Total Renewals",
+      "value": 0,
+      "display": null
+    },
+    "78": {
+      "label": "Last Checkout Date",
+      "value": "2015-06-11T20:57:05Z",
+      "display": null
+    },
+    "79": {
+      "label": "Location",
+      "value": "rcpr2",
+      "display": "OFFSITE - Request in Advance for use at Performing Arts"
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "i",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "23937039",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2009-06-20T14:13:42Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2017-09-08T19:57:49Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "31",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "88": {
+      "label": "Status",
+      "value": "-",
+      "display": "AVAILABLE"
+    },
+    "93": {
+      "label": "Inhouse Use",
+      "value": 0,
+      "display": null
+    },
+    "94": {
+      "label": "Copy Use",
+      "value": 0,
+      "display": null
+    },
+    "97": {
+      "label": "Item Message",
+      "value": "x",
+      "display": null
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2017-05-08T13:08:12Z",
+      "display": null
+    },
+    "108": {
+      "label": "OPAC Message",
+      "value": "a",
+      "display": null
+    },
+    "109": {
+      "label": "Year-to-Date Circ",
+      "value": 0,
+      "display": null
+    },
+    "110": {
+      "label": "Last Year Circ",
+      "value": 0,
+      "display": null
+    },
+    "127": {
+      "label": "Item Agency",
+      "value": "219",
+      "display": "ReCAP (NN) - LPA Media Center"
+    },
+    "161": {
+      "label": "VI Central",
+      "value": 0,
+      "display": null
+    },
+    "162": {
+      "label": "IR Dist Learn Same Site",
+      "value": "0",
+      "display": null
+    },
+    "264": {
+      "label": "Holdings Item Tag",
+      "value": "6",
+      "display": null
+    },
+    "265": {
+      "label": "Inherit Location",
+      "value": false,
+      "display": null
+    },
+    "306": {
+      "label": "Sticky Status",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "a",
+      "marcTag": "945",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "1993-06-03"
+        },
+        {
+          "tag": "b",
+          "content": "07/22/2008"
+        },
+        {
+          "tag": "e",
+          "content": "FILM"
+        },
+        {
+          "tag": "f",
+          "content": "6"
+        },
+        {
+          "tag": "g",
+          "content": "M16 3584 W"
+        },
+        {
+          "tag": "h",
+          "content": "NYPL"
+        },
+        {
+          "tag": "i",
+          "content": "MY"
+        },
+        {
+          "tag": "j",
+          "content": "TF"
+        },
+        {
+          "tag": "l",
+          "content": "2009-04-16"
+        },
+        {
+          "tag": "m",
+          "content": "898"
+        },
+        {
+          "tag": "n",
+          "content": "DMCAFILM"
+        },
+        {
+          "tag": "o",
+          "content": "DMCAFILM"
+        },
+        {
+          "tag": "r",
+          "content": "600.00"
+        },
+        {
+          "tag": "s",
+          "content": "C.1 REEL 1 OF 2"
+        },
+        {
+          "tag": "t",
+          "content": "CIRCS"
+        },
+        {
+          "tag": "u",
+          "content": "33433081307138"
+        },
+        {
+          "tag": "v",
+          "content": "mya  "
+        },
+        {
+          "tag": "w",
+          "content": "myzzz"
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "33433081307138",
+      "subfields": null
+    },
+    {
+      "fieldTag": "d",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "1993-06-03",
+      "subfields": null
+    },
+    {
+      "fieldTag": "e",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "2009-04-16",
+      "subfields": null
+    },
+    {
+      "fieldTag": "x",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "C.1 REEL 1 OF 2",
+      "subfields": null
+    }
+  ]
+}

--- a/test/item-marc-test.js
+++ b/test/item-marc-test.js
@@ -55,7 +55,7 @@ describe('Item Marc Mapping', function () {
       return itemSerializer.fromMarcJson(item)
         .then((statements) => new Item(statements))
         .then((item) => {
-          assert.equal(item.objectId('rdf:type'), 'bf:Item')
+          assert.equal(item.objectId('rdfs:type'), 'bf:Item')
           assert.equal(item.objectId('nypl:owner'), 'orgs:1000')
           // This one happens to have a [faked] duedate, so will appear unavailable:
           assert.equal(item.objectId('bf:status'), 'status:co')
@@ -75,7 +75,7 @@ describe('Item Marc Mapping', function () {
       return itemSerializer.fromMarcJson(item)
         .then((statements) => new Item(statements))
         .then((item) => {
-          assert.equal(item.objectId('rdf:type'), 'bf:Item')
+          assert.equal(item.objectId('rdfs:type'), 'bf:Item')
           assert.equal(item.objectId('nypl:owner'), 'orgs:1000')
           assert.equal(item.objectId('bf:status'), 'status:a')
           assert.equal(item.objectId('nypl:holdingLocation'), 'loc:rcma2')
@@ -93,7 +93,7 @@ describe('Item Marc Mapping', function () {
       return itemSerializer.fromMarcJson(item)
         .then((statements) => new Item(statements))
         .then((item) => {
-          assert.equal(item.objectId('rdf:type'), 'bf:Item')
+          assert.equal(item.objectId('rdfs:type'), 'bf:Item')
           assert.equal(item.objectId('nypl:bnum'), 'urn:bnum:b17355748')
           assert.equal(item.literal('nypl:suppressed'), true)
           // Make sure no other statements are being saved for this item because it's branch
@@ -112,7 +112,7 @@ describe('Item Marc Mapping', function () {
       return itemSerializer.fromMarcJson(item)
         .then((statements) => new Item(statements))
         .then((item) => {
-          assert.equal(item.objectId('rdf:type'), 'bf:Item')
+          assert.equal(item.objectId('rdfs:type'), 'bf:Item')
           assert.equal(item.objectId('nypl:bnum'), 'urn:bnum:b17664294')
           assert.equal(item.literal('nypl:suppressed'), false)
           // itypes greater than 100 are normally non-research, but some are research!
@@ -191,7 +191,7 @@ describe('Item Marc Mapping', function () {
         .then((statements) => new Item(statements))
         .then((item) => {
           // TODO need to check a whole bunch more fields...
-          assert.equal(item.objectId('rdf:type'), 'bf:Item')
+          assert.equal(item.objectId('rdfs:type'), 'bf:Item')
           assert.equal(item.objectId('nypl:bnum'), 'urn:bnum:pb176961')
           // No item types currently assigned to PUL/CUL
           assert.equal(item.objectId('nypl:catalogItemType'), 'catalogItemType:1')
@@ -212,7 +212,7 @@ describe('Item Marc Mapping', function () {
       return itemSerializer.fromMarcJson(item)
         .then((statements) => new Item(statements))
         .then((item) => {
-          assert.equal(item.objectId('rdf:type'), 'bf:Item')
+          assert.equal(item.objectId('rdfs:type'), 'bf:Item')
           assert.equal(item.objectId('nypl:bnum'), 'urn:bnum:b10006965')
           assert.equal(item.objectId('nypl:catalogItemType'), 'catalogItemType:6')
           assert.equal(item.objectId('nypl:owner'), 'orgs:1000')
@@ -234,7 +234,7 @@ describe('Item Marc Mapping', function () {
       return itemSerializer.fromMarcJson(item)
         .then((statements) => new Item(statements))
         .then((item) => {
-          assert.equal(item.objectId('rdf:type'), 'bf:Item')
+          assert.equal(item.objectId('rdfs:type'), 'bf:Item')
           assert.equal(item.literal('nypl:suppressed'), true)
 
           // Because we modified the object, clear require cache
@@ -257,7 +257,7 @@ describe('Item Marc Mapping', function () {
       return itemSerializer.fromMarcJson(item)
         .then((statements) => new Item(statements))
         .then((item) => {
-          assert.equal(item.objectId('rdf:type'), 'bf:Item')
+          assert.equal(item.objectId('rdfs:type'), 'bf:Item')
           assert.equal(item.literal('nypl:suppressed'), true)
 
           // Because we modified the object, clear require cache
@@ -278,7 +278,7 @@ describe('Item Marc Mapping', function () {
       return itemSerializer.fromMarcJson(item)
         .then((statements) => new Item(statements))
         .then((item) => {
-          assert.equal(item.objectId('rdf:type'), 'bf:Item')
+          assert.equal(item.objectId('rdfs:type'), 'bf:Item')
           // Note we can't check 'nypl:catalogItemType' because almost nothing apart form nypl:suppressed is being serialized
           assert.equal(item.literal('nypl:suppressed'), true)
 
@@ -301,7 +301,7 @@ describe('Item Marc Mapping', function () {
         return itemSerializer.fromMarcJson(item)
           .then((statements) => new Item(statements))
           .then((item) => {
-            assert.equal(item.objectId('rdf:type'), 'bf:Item')
+            assert.equal(item.objectId('rdfs:type'), 'bf:Item')
             // Of the five values we setting, only '-' should cause item to be not suppressed
             assert.equal(item.literal('nypl:suppressed'), code !== '-')
 


### PR DESCRIPTION
This PR implements SRCH-298, which suppresses Notes if `ind1` is '0'. This rule was previously only applied to 541 and 561. It now applies to all 'Note' mappings.