### PR TITLE
SRCH-301 — Update title display serialization

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -39,5 +39,8 @@
   "kinesisReadStreams": {
     "bib": "",
     "item": ""
+  },
+  "nyplCoreMappings": {
+    "version_tag": "v1.1"
   }
 }

--- a/lib/field-mapper.js
+++ b/lib/field-mapper.js
@@ -1,3 +1,4 @@
+const config = require('config')
 const syncRequest = require('sync-request')
 
 let _file_cache = {}
@@ -89,7 +90,7 @@ var amendMappingsBasedOnNyplSource = (data, nyplSource) => {
  */
 function buildMapper (type, nyplSource) {
   if (['bib', 'item'].indexOf(type) >= 0) {
-    let data = requireRemote(`https://raw.githubusercontent.com/NYPL/nypl-core/master/mappings/recap-discovery/field-mapping-${type}.json#v1.1`)
+    let data = requireRemote(`https://raw.githubusercontent.com/NYPL/nypl-core/${config.nyplCoreMappings.version_tag}/mappings/recap-discovery/field-mapping-${type}.json`)
 
     // If nyplSource given, trim mappings to agree with it:
     if (nyplSource) data = amendMappingsBasedOnNyplSource(data, nyplSource)

--- a/lib/field-mapper.js
+++ b/lib/field-mapper.js
@@ -89,7 +89,7 @@ var amendMappingsBasedOnNyplSource = (data, nyplSource) => {
  */
 function buildMapper (type, nyplSource) {
   if (['bib', 'item'].indexOf(type) >= 0) {
-    let data = requireRemote(`https://raw.githubusercontent.com/NYPL/nypl-core/master/mappings/recap-discovery/field-mapping-${type}.json`)
+    let data = requireRemote(`https://raw.githubusercontent.com/NYPL/nypl-core/master/mappings/recap-discovery/field-mapping-${type}.json#v1.1`)
 
     // If nyplSource given, trim mappings to agree with it:
     if (nyplSource) data = amendMappingsBasedOnNyplSource(data, nyplSource)

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -233,7 +233,7 @@ describe('Bib Marc Mapping', function () {
         })
     })
 
-    it('should map carrier type, dimensions, extent, alt title', function () {
+    it('should map carrier type, dimensions, extent, alt title, display title', function () {
       var bib = BibSierraRecord.from(require('./data/bib-18501478.json'))
 
       return bibSerializer.fromMarcJson(bib)
@@ -248,6 +248,9 @@ describe('Bib Marc Mapping', function () {
           assert.equal(bib.literal('nypl:extent'), 'v. ;')
 
           assert.equal(bib.literal('dcterms:alternative'), 'Cobbett\'s weekly political register (London, England : 1802)')
+          assert.equal(
+            bib.literal('nypl:titleDisplay'), 'Cobbett\'s weekly political register [electronic resource].'
+          )
         })
     })
 

--- a/test/data/bib-18501478.json
+++ b/test/data/bib-18501478.json
@@ -406,6 +406,14 @@
       "content": null,
       "subFields": [
         {
+          "tag": "6",
+          "content": "tag-6"
+        },
+        {
+          "tag": "8",
+          "content": "tag-8"
+        },
+        {
           "tag": "a",
           "content": "Cobbett's weekly political register"
         },


### PR DESCRIPTION
Display Title was pulling in two subfields from the MARC record which it shouldn't have been using. The actual fix is in `nypl-record` but I added tests in this project. 

Additionally, as there are potentially issues with updating `nypl-core` without updating `pcdm-store-udpater` (breaking functionality, failing tests, apps running in an inconsistent state) I am starting to use a specific version tag to track changes in `nypl-core`.