### PR TITLE
Fix cmd-line utilities broken by config/deploy standards change

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ When a brand new environment is created, you'll need to initialize the DB enviro
 To verify that you've entered your encrypted creds correctly and that KMS is able to decrypt them to DB credentials, run the following:
 
 ```
-node jobs/init.js check --envfile config/[environment].env
+node jobs/init.js check --envfile config/[environment].env --profile [aws profile]
 ```
 
 If no errors are thrown, and the reported creds look correct, proceed with DB creation:
@@ -69,7 +69,7 @@ If no errors are thrown, and the reported creds look correct, proceed with DB cr
 The following will create necessary tables in the DB instance (identified in specified `--envfile`):
 
 ```
-node jobs/init.js create --envfile config/[environment].env
+node jobs/init.js create --envfile config/[environment].env --profile [aws profile]
 ```
 
 To verify that the serialization works on a sample document, you can run the following:
@@ -91,6 +91,8 @@ node jobs/update-bibs.js [opts]
 ```
 
 `Opts` can include:
+* `profile`: AWS profile (required)
+* `envfile`: Node-lambda .env file containing deployed ENV vars (required)
 * `offset`: Start at index
 * `limit`: Limit to this number of records
 * `skip`: Skip this many (useful if starting offset unknown)
@@ -116,6 +118,8 @@ node jobs/update-items.js [opts]
 ```
 
 `Opts` can include:
+* `profile`: AWS profile (required)
+* `envfile`: Node-lambda .env file containing deployed ENV vars (required)
 * `offset`: Start at index
 * `limit`: Limit to this number of records
 * `uri`: Process specific bib (from cache)

--- a/jobs/init.js
+++ b/jobs/init.js
@@ -93,9 +93,8 @@ if (COMMANDS.indexOf(command) < 0) exitWithError('Invalid command.')
 // Require an envfile:
 if (!argv.envfile) exitWithError('Must specify --envfile FILE')
 
-// Load env files:
-require('dotenv').config({ path: argv.envfile })
-require('dotenv').config({ path: './.env' })
+// Load up AWS creds:
+require('../lib/local-env-helper')
 
 const kmsHelper = require('../lib/kms-helper')
 const db = require('../lib/db')

--- a/jobs/update-bibs.js
+++ b/jobs/update-bibs.js
@@ -8,6 +8,8 @@ const BibsUpdater = require('../lib/bibs-updater')
 
 var argv = require('optimist')
   .usage('Usage: $0 [--offset=num] [--limit=num]')
+  .describe('profile', 'AWS profile (required)')
+  .describe('envfile', 'Node-lambda .env file containing deployed ENV vars (required)')
   .describe('offset', 'Start at index')
   .describe('skip', 'Skip this many (useful if starting offset unknown)')
   .describe('seek', 'skip everything except this id')
@@ -30,8 +32,8 @@ var opts = {
 // If --until given, dynamically set limit:
 if (argv.until) argv.limit = argv.until - (argv.offset || 0) + 1
 
-require('dotenv').config({ path: './deploy.env' })
-require('dotenv').config({ path: './.env' })
+// Load up AWS creds:
+require('../lib/local-env-helper')
 
 log.setLevel(argv.loglevel || process.env.LOGLEVEL || 'info')
 

--- a/jobs/update-items.js
+++ b/jobs/update-items.js
@@ -8,6 +8,8 @@ const ItemsUpdater = require('../lib/items-updater')
 
 var argv = require('optimist')
   .usage('Usage: $0 [--offset=num] [--limit=num]')
+  .describe('profile', 'AWS profile (required)')
+  .describe('envfile', 'Node-lambda *.env file containing deployed ENV vars (required)')
   .describe('offset', 'Start at index')
   .describe('limit', 'Limit to this number of records')
   .describe('uri_cache', 'Process specific item by prefixed uri (from cache)')
@@ -26,8 +28,8 @@ var opts = {
   seek: argv.uri_seek || null
 }
 
-require('dotenv').config({ path: './deploy.env' })
-require('dotenv').config({ path: './.env' })
+// Load up AWS creds:
+require('../lib/local-env-helper')
 
 log.setLevel(argv.loglevel || process.env.LOGLEVEL || 'info')
 

--- a/lib/local-env-helper.js
+++ b/lib/local-env-helper.js
@@ -1,13 +1,15 @@
 /**
- *  This include should required by any command-line utility that requires AWS
+ *  This include should be required by any cmd-line utility that requires AWS
  *  credentials and environment-specific ENV variables. By including this file,
  *  the process.argv will be inspected for the following params:
  *
  *   - `--profile`: AWS profile to use
  *   - `--envfile`: Path to an environment env file containing deployable ENV
- *                  varialbes (e.g. config/qa.env)
+ *                  variables (e.g. config/qa.env)
  *
- *  If both parameters are given, any aws-sdk calls made subsequently will be
+ *  Both parameters are required. If either is missing, an Error will be thrown.
+ *
+ *  When both parameters are given, any aws-sdk calls made subsequently will be
  *  auth'd against the indicated account and the ENV will be populated with the
  *  contents of the given envfile.
  */

--- a/lib/local-env-helper.js
+++ b/lib/local-env-helper.js
@@ -28,8 +28,7 @@ function setProfile (profile) {
   aws.config.update(awsSecurity)
 }
 
-var argv = require('optimist')
-  .argv
+var argv = require('optimist').argv
 
 // Require both --profile and --envfile
 if (!argv.profile) throw new Error('--profile [aws profile] is a required flag')

--- a/lib/local-env-helper.js
+++ b/lib/local-env-helper.js
@@ -1,0 +1,40 @@
+/**
+ *  This include should required by any command-line utility that requires AWS
+ *  credentials and environment-specific ENV variables. By including this file,
+ *  the process.argv will be inspected for the following params:
+ *
+ *   - `--profile`: AWS profile to use
+ *   - `--envfile`: Path to an environment env file containing deployable ENV
+ *                  varialbes (e.g. config/qa.env)
+ *
+ *  If both parameters are given, any aws-sdk calls made subsequently will be
+ *  auth'd against the indicated account and the ENV will be populated with the
+ *  contents of the given envfile.
+ */
+
+const aws = require('aws-sdk')
+const dotenv = require('dotenv')
+
+function setProfile (profile) {
+  // Set aws creds:
+  aws.config.credentials = new aws.SharedIniFileCredentials({
+    profile: profile
+  })
+
+  // Set aws region:
+  let awsSecurity = { region: 'us-east-1' }
+  aws.config.update(awsSecurity)
+}
+
+var argv = require('optimist')
+  .argv
+
+// Require both --profile and --envfile
+if (!argv.profile) throw new Error('--profile [aws profile] is a required flag')
+if (!argv.envfile) throw new Error('--envfile config/[environment].env is a required flag')
+
+// Load nypl-data-api-client required config:
+dotenv.config({ path: argv.envfile })
+
+// Set active aws profile (so that kms knows how to decrypt things)
+setProfile(argv.profile)


### PR DESCRIPTION
This PR patches known issues in command-line utilities due to https://github.com/NYPL-discovery/pcdm-store-updater/pull/42 . Running any script in `jobs/` now requires the following params:

 - `--profile`: AWS profile to use
 - `--envfile`: Path to an environment env file containing deployable ENV varialbes (e.g. config/qa.env)

Patching these jobs will allow us to more easily run ad hoc tests against specific bibs/items in staging.