### PR TITLE
SRCH-319: pcdm-store-updater will look up bibIds

### DIFF
--- a/lib/items-updater.js
+++ b/lib/items-updater.js
@@ -150,13 +150,19 @@ class ItemsUpdater extends UpdaterBase {
    */
   _getBibIdsForItemStatements (statements) {
     // Build hash mapping subject_ids to array of statements:
-    let subjectIdGroups = utils.groupBy(statements, 'subject_id')
+    let subjectIdGroups = statements.reduce((hash, statement) => {
+      if (!hash[statement.subject_id]) hash[statement.subject_id] = []
+      hash[statement.subject_id].push(statement)
+      return hash
+    }, {})
 
-    // Turn that into a hash mapping subject_ids to bibId (or null if no bibId found):
-    let subjectIdsToBibIds = Object.keys(subjectIdGroups).map((subjectId) => {
+    // Turn that hash into a hash mapping subject_ids to bibId (or null if no
+    // bibId found):
+    let subjectIdsToBibIds = Object.keys(subjectIdGroups).reduce((hash, subjectId) => {
       let bibIdStatement = subjectIdGroups[subjectId].filter((statement) => statement.predicate === 'nypl:bnum')[0]
-      return bibIdStatement ? bibIdStatement.object_id.replace('urn:bnum:', '') : null
-    })
+      hash[subjectId] = bibIdStatement ? bibIdStatement.object_id.replace('urn:bnum:', '') : null
+      return hash
+    }, {})
 
     // Since some of those bibIds will be null (item deletion), map our bibIds
     // to an array of Promises that fill in missing bibIds via db lookup:

--- a/lib/items-updater.js
+++ b/lib/items-updater.js
@@ -146,7 +146,29 @@ class ItemsUpdater extends UpdaterBase {
     let schemaName = process.env.INDEX_DOCUMENT_SCHEMA_NAME
     // Make sure stream-writing is configured
     if (streamName && schemaName) {
+      // Build hash mapping subject_ids to array of statements:
+      let subjectIdGroups = utils.groupBy(batch, 'subject_id')
+
+      // Turn that into a hash mapping subject_ids to bibId (or null if no bibId found):
+      let subjectIdsToBibIds = Object.keys(subjectIdGroups).map((subjectId) => {
+        let bibIdStatement = subjectIdGroups[subjectId].filter((statement) => statement.predicate === 'nypl:bnum')[0]
+        return bibIdStatement ? bibIdStatement.object_id.replace('urn:bnum:', '') : null
+      })
+
+      // Since some of those bibIds will be null (item deletion), map our bibIds
+      // to an array of Promises that fill in missing bibIds via db lookup:
+      let bibIdsToReindex = Object.keys(subjectIdsToBibIds).map((subjectId) => {
+        // If bibId is set, resolve it immediately:
+        if (subjectIdsToBibIds[subjectId]) return Promise.resolve(subjectIdsToBibIds[subjectId])
+        else {
+          // Otherwise look it up in the db:
+          return db.getStatement('resource', subjectId, 'nypl:bnum')
+            .then((result) => result.object_id.replace('urn:bnum:', ''))
+        }
+      })
+
       // Get distinct bib ids by grabbing distinct objectIds from the known nypl:bnum pred
+      /*
       var distinctBibIds = Object.keys(
         batch
           .filter((s) => s.predicate === 'nypl:bnum')
@@ -160,8 +182,14 @@ class ItemsUpdater extends UpdaterBase {
       var recs = distinctBibIds.map((uri) => {
         return { type: 'record', uri }
       })
-      return this._writeToStreamsClient(streamName, recs, schemaName)
-        .then(() => log.debug(`Wrote ${recs.length} to ${streamName} (encoded against ${schemaName})`))
+      */
+      return Promise.all(bibIdsToReindex).then((bibIds) => {
+        let kinesisRecords = bibIds.map((bibId) => {
+          return { type: 'record', uri: bibId }
+        })
+        return this._writeToStreamsClient(streamName, kinesisRecords, schemaName)
+          .then(() => log.debug(`Wrote ${kinesisRecords.length} to ${streamName} (encoded against ${schemaName})`))
+      })
     } else return Promise.resolve(batch)
   }
 

--- a/lib/items-updater.js
+++ b/lib/items-updater.js
@@ -140,56 +140,58 @@ class ItemsUpdater extends UpdaterBase {
     })
   }
 
-  // Takes a batch of inserted records, writes to IndexDocument stream
+  /**
+   * This method takes an array of item statements (presumably bound for the
+   * database) and extracts all of the bibIds. If the bibId can not be
+   * determined for any item (i.e. when processing item deletion), the bibId
+   * will be looked up in the database.
+   *
+   * Returns a Promise that resolves all bibIds.
+   */
+  _getBibIdsForItemStatements (statements) {
+    // Build hash mapping subject_ids to array of statements:
+    let subjectIdGroups = utils.groupBy(statements, 'subject_id')
+
+    // Turn that into a hash mapping subject_ids to bibId (or null if no bibId found):
+    let subjectIdsToBibIds = Object.keys(subjectIdGroups).map((subjectId) => {
+      let bibIdStatement = subjectIdGroups[subjectId].filter((statement) => statement.predicate === 'nypl:bnum')[0]
+      return bibIdStatement ? bibIdStatement.object_id.replace('urn:bnum:', '') : null
+    })
+
+    // Since some of those bibIds will be null (item deletion), map our bibIds
+    // to an array of Promises that fill in missing bibIds via db lookup:
+    let bibIdsToReindex = Object.keys(subjectIdsToBibIds).map((subjectId) => {
+      // If bibId is set, resolve it immediately:
+      if (subjectIdsToBibIds[subjectId]) return Promise.resolve(subjectIdsToBibIds[subjectId])
+      else {
+        // Otherwise look it up in the db:
+        return db.getStatement('resource', subjectId, 'nypl:bnum')
+          .then((result) => result.object_id.replace('urn:bnum:', ''))
+      }
+    })
+
+    return Promise.all(bibIdsToReindex)
+  }
+
+  /**
+   * This method takes a batch of inserted item statements and 1) identifies
+   * all parent bibIds (even if bibIds not present in those statements), and
+   * 2) posts them to the configured "IndexDocumentQueue-*" stream (which
+   * triggers reindexing by the discovery-api-indexer)
+   */
   _writeToIndexDocumentQueue (batch) {
     let streamName = process.env.INDEX_DOCUMENT_STREAM_NAME
     let schemaName = process.env.INDEX_DOCUMENT_SCHEMA_NAME
     // Make sure stream-writing is configured
     if (streamName && schemaName) {
-      // Build hash mapping subject_ids to array of statements:
-      let subjectIdGroups = utils.groupBy(batch, 'subject_id')
-
-      // Turn that into a hash mapping subject_ids to bibId (or null if no bibId found):
-      let subjectIdsToBibIds = Object.keys(subjectIdGroups).map((subjectId) => {
-        let bibIdStatement = subjectIdGroups[subjectId].filter((statement) => statement.predicate === 'nypl:bnum')[0]
-        return bibIdStatement ? bibIdStatement.object_id.replace('urn:bnum:', '') : null
-      })
-
-      // Since some of those bibIds will be null (item deletion), map our bibIds
-      // to an array of Promises that fill in missing bibIds via db lookup:
-      let bibIdsToReindex = Object.keys(subjectIdsToBibIds).map((subjectId) => {
-        // If bibId is set, resolve it immediately:
-        if (subjectIdsToBibIds[subjectId]) return Promise.resolve(subjectIdsToBibIds[subjectId])
-        else {
-          // Otherwise look it up in the db:
-          return db.getStatement('resource', subjectId, 'nypl:bnum')
-            .then((result) => result.object_id.replace('urn:bnum:', ''))
-        }
-      })
-
-      // Get distinct bib ids by grabbing distinct objectIds from the known nypl:bnum pred
-      /*
-      var distinctBibIds = Object.keys(
-        batch
-          .filter((s) => s.predicate === 'nypl:bnum')
-          .map((s) => s.object_id.replace('urn:bnum:', ''))
-          .reduce((h, bnum) => {
-            h[bnum] = true
-            return h
-          }, {})
-      )
-      // Submit bib ids to write stream:
-      var recs = distinctBibIds.map((uri) => {
-        return { type: 'record', uri }
-      })
-      */
-      return Promise.all(bibIdsToReindex).then((bibIds) => {
-        let kinesisRecords = bibIds.map((bibId) => {
-          return { type: 'record', uri: bibId }
+      this._getBibIdsForItemStatements(batch)
+        .then((bibIds) => {
+          let kinesisRecords = bibIds.map((bibId) => {
+            return { type: 'record', uri: bibId }
+          })
+          return this._writeToStreamsClient(streamName, kinesisRecords, schemaName)
+            .then(() => log.debug(`Wrote ${kinesisRecords.length} to ${streamName} (encoded against ${schemaName})`))
         })
-        return this._writeToStreamsClient(streamName, kinesisRecords, schemaName)
-          .then(() => log.debug(`Wrote ${kinesisRecords.length} to ${streamName} (encoded against ${schemaName})`))
-      })
     } else return Promise.resolve(batch)
   }
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dotenv": "^4.0.0",
     "mocha": "^3.5.0",
     "node-lambda": "^0.11.3",
+    "sinon": "^4.0.1",
     "standard": "6.0.8"
   },
   "scripts": {

--- a/test/items-updater-test.js
+++ b/test/items-updater-test.js
@@ -1,0 +1,75 @@
+/* global describe it before after */
+
+const sinon = require('sinon')
+
+const assert = require('assert')
+const ItemsUpdater = require('./../lib/items-updater')
+const db = require('./../lib/db')
+const ItemSierraRecord = require('./../lib/models/item-sierra-record')
+
+describe('Items Updater', function () {
+  describe('_getBibIdsForItemStatements', function () {
+    before(() => {
+      sinon.stub(db, 'getStatement').callsFake((type, subjectId, predicate) => {
+        // Mocked for single test lookup:
+        return Promise.resolve({
+          subject_id: 'ci5651186',
+          predicate: 'nypl:bnum',
+          object_id: 'urn:bnum:cb4194299'
+        })
+      })
+    })
+
+    after(() => {
+      db.getStatement.restore()
+    })
+
+    it('should derive bibId from statements if given', function () {
+      let itemRecord = ItemSierraRecord.from({
+        'id': '5651186',
+        'nyplSource': 'recap-cul',
+        'nyplType': 'item',
+        'bibIds': ['1234-bib-id-given-in-record']
+      })
+      // First run this record through the serializer to extract item statements
+      return ItemsUpdater.prototype.extractStatements(itemRecord)
+        .then((statements) => {
+          // Now run those statements through this utility function that
+          // identifies the bibIds that need to be reindexed based on the
+          // item statements:
+          return ItemsUpdater.prototype._getBibIdsForItemStatements(statements)
+            .then((bibIdsToReindex) => {
+              // We expect a single bibId to be extracted matching the value
+              // in the moch marc-json (with 'cb' prefix):
+              assert.equal(bibIdsToReindex.length, 1)
+              assert.equal(bibIdsToReindex[0], 'cb1234-bib-id-given-in-record')
+            })
+        })
+    })
+
+    it('should lookup bibIds if missing', function () {
+      // This is what a item marc json record looks like when it's deleted:
+      let itemRecord = ItemSierraRecord.from({
+        'id': '5651186',
+        'nyplSource': 'recap-cul',
+        'nyplType': 'item',
+        'deletedDate': '2011-02-28',
+        'deleted': true
+      })
+      // First run this record through the serializer to extract item statements
+      return ItemsUpdater.prototype.extractStatements(itemRecord)
+        .then((statements) => {
+          // Now run those statements through this utility function that
+          // identifies the bibIds that need to be reindexed based on the
+          // item statements:
+          return ItemsUpdater.prototype._getBibIdsForItemStatements(statements)
+            .then((bibIdsToReindex) => {
+              // We expect a single bibId derived from db (stubbed with
+              // mocked response above):
+              assert.equal(bibIdsToReindex.length, 1)
+              assert.equal(bibIdsToReindex[0], 'cb4194299')
+            })
+        })
+    })
+  })
+})


### PR DESCRIPTION
This PR ensures that the current default representation of a deleted item is an acceptable input to the pcdm-store-updater. Currently, the app issues all the right deletions against the discovery-store, but fails to trigger a reindex on the effected bib. It fails because the current default representation of a deleted item intentionally omits the `bibIds` property. This PR patches the updater to ensure that effected `bibId`s are derived from the discovery-store itself for any item deleted.

If the discovery-store doesn't have the bibId for any item being deleted, presumably it has never existed in the database to begin with and does not need to be removed from the index.