### PR TITLE
Log error if schema fetch or parse fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,10 @@ function processEvent (event, context, callback) {
         log.trace(error)
         callback(error)
       })
+  }).catch((error) => {
+    log.error(`processEvent: Error fetching schema (${bibOrItem})`)
+    log.trace(error)
+    callback(error)
   })
 }
 


### PR DESCRIPTION
This patches the app to ensure an error is logged and callback is called with error if the `dataApi` client returns an error (i.e. 5xx, 4xx) or `avsc` fails to parse the returned data. 