### PR TITLE
Fix bug where three bib fields saved wrong index

### DIFF
--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -236,7 +236,7 @@ var fromMarcJson = (object, datasource) => {
         callnum.value += ' ' + callnumSuffix[0]
         callnum.path += ', fieldTag v'
       }
-      builder.add(fieldMapper.predicateFor('Call number'), { literal: callnum.value }, { path: callnum.path })
+      builder.add(fieldMapper.predicateFor('Call number'), { literal: callnum.value }, 0, { path: callnum.path })
     }
 
     // Subject literal
@@ -274,7 +274,7 @@ var fromMarcJson = (object, datasource) => {
       fieldMapping.paths.forEach((path) => {
         var partOfValues = object.varField(path.marc, path.subfields)
         if (partOfValues && partOfValues.length > 0) {
-          partOfValues.forEach((partOfValue) => {
+          partOfValues.forEach((partOfValue, index) => {
             builder.add(fieldMapping.pred, { literal: partOfValue }, index, { path: `${path.marc} ${path.subfields.join(' ')}` })
           })
         }
@@ -286,7 +286,7 @@ var fromMarcJson = (object, datasource) => {
       fieldMapping.paths.forEach((path) => {
         var genreFormValues = object.varField(path.marc, path.subfields, { subfieldJoiner: ' – ' })
         if (genreFormValues && genreFormValues.length > 0) {
-          genreFormValues.forEach((genreFormValue) => {
+          genreFormValues.forEach((genreFormValue, index) => {
             let sourceRecordPath = `${path.marc} ${path.subfields.map((subfield) => `$${subfield}`).join(' ')}`
             builder.add(fieldMapping.pred, { literal: genreFormValue }, index, { path: sourceRecordPath })
           })


### PR DESCRIPTION
This patches a minor issue where three rules were calling builder.add
with the wrong - or a missing - index argument. This does not prevent
the statement from being saved, but saves it with a missing/invalid
index column, which will prevent multiple values from being saved on the
same predicate as well as potentially prevent source_record_path from
being saved with the record. The effected predicates are Genre/form,
Part of, and Call Number