### PR TITLE
Blank node support

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -359,7 +359,18 @@ var groupStatementsBySubjectPredicateAndMaxIndex = (statements) => {
  * which identify statements about this subject that we may wish to delete.
  */
 var unusedPredicates = (usedPredicates, type) => {
+  // Get all predicates currently involved in mapping:
   let allPredicates = require('./field-mapper')(type).allPredicates()
+
+  // TODO We need to make this automatic. Should identify all predicates used
+  // for a given type (bib, item, note, etc) and delete anything previously
+  // created for a given subject by this creator.
+  // For now, we'll just collect the predicates here that we know to be stale
+  // in most clases
+  // Add deprecated predicates previously used, but no longer found in mapping here:
+  allPredicates = allPredicates.concat(['skos:note', 'rdf:type'])
+
+  // Calculate unused preds as those in `allPredicates` not found in `usedPredicates`
   return allPredicates.filter((predicate) => usedPredicates.indexOf(predicate) < 0)
 }
 

--- a/lib/field-mapper.js
+++ b/lib/field-mapper.js
@@ -89,7 +89,7 @@ var amendMappingsBasedOnNyplSource = (data, nyplSource) => {
  */
 function buildMapper (type, nyplSource) {
   if (['bib', 'item'].indexOf(type) >= 0) {
-    let data = requireRemote(`https://raw.githubusercontent.com/NYPL/nypl-core/${process.env.NYPL_CORE_VERSION || 'v1.4a'}/mappings/recap-discovery/field-mapping-${type}.json`)
+    let data = requireRemote(`https://raw.githubusercontent.com/NYPL/nypl-core/${process.env.NYPL_CORE_VERSION || 'v1.5'}/mappings/recap-discovery/field-mapping-${type}.json`)
 
     // If nyplSource given, trim mappings to agree with it:
     if (nyplSource) data = amendMappingsBasedOnNyplSource(data, nyplSource)

--- a/lib/field-mapper.js
+++ b/lib/field-mapper.js
@@ -89,7 +89,7 @@ var amendMappingsBasedOnNyplSource = (data, nyplSource) => {
  */
 function buildMapper (type, nyplSource) {
   if (['bib', 'item'].indexOf(type) >= 0) {
-    let data = requireRemote(`https://raw.githubusercontent.com/NYPL/nypl-core/${process.env.NYPL_CORE_VERSION || 'v1.5'}/mappings/recap-discovery/field-mapping-${type}.json`)
+    let data = requireRemote(`https://raw.githubusercontent.com/NYPL/nypl-core/${process.env.NYPL_CORE_VERSION || 'master'}/mappings/recap-discovery/field-mapping-${type}.json`)
 
     // If nyplSource given, trim mappings to agree with it:
     if (nyplSource) data = amendMappingsBasedOnNyplSource(data, nyplSource)

--- a/lib/models/base.js
+++ b/lib/models/base.js
@@ -7,7 +7,30 @@ const DB_ENTITY_CACHE = process.env.DB_ENTITY_CACHE === 'true'
 
 class Base {
   constructor (stmts) {
+    // Assume first statement has primary record as subject:
+    if (stmts && stmts.length > 0) this.id = stmts[0].subject_id
+
     this._statements = stmts
+      .filter((s) => s.subject_id === this.id)
+
+    // Group blank node statements:
+    const blankNodeStatementsGrouped = stmts
+      // Filter out anything referring to primary subject:
+      .filter((s) => s.subject_id !== this.id)
+      // Group blank node statements by subject_id:
+      .reduce((blankNodeStatementsById, statement) => {
+        if (!blankNodeStatementsById[statement.subject_id]) blankNodeStatementsById[statement.subject_id] = []
+
+        blankNodeStatementsById[statement.subject_id].push(statement)
+        return blankNodeStatementsById
+      }, {})
+
+    // Build internal hash of blank nodes (as instances of `Base`)
+    this._blankNodes = Object.keys(blankNodeStatementsGrouped).reduce((h, blankNodeId) => {
+      h[blankNodeId] = new Base(blankNodeStatementsGrouped[blankNodeId])
+      return h
+    }, {})
+
     if (this._statements && this._statements.length > 0) this.id = this._statements[0].subject_id
   }
 
@@ -34,6 +57,13 @@ class Base {
 
   objectId (pred) {
     return this.objectIds(pred)[0]
+  }
+
+  blankNodes (pred) {
+    return this.statements(pred)
+      // Ensure statement refers to a blank node in our hash:
+      .filter((s) => this._blankNodes[s.object_id])
+      .map((s) => this._blankNodes[s.object_id])
   }
 
   label () {

--- a/lib/models/statement.js
+++ b/lib/models/statement.js
@@ -11,6 +11,11 @@ class Statement {
   }
 }
 
+/**
+ * A statement builder is an object initialized with a fixed creator_id and
+ * base_source_hash, which ensures that an `add` (or `addBlankNode`) calls
+ * made upon it use that baseline provenance info in generated statements.
+ */
 Statement.builder = (subject_id, creator_id, base_source_hash) => {
   if (!base_source_hash.id) throw new Error(subject_id + ': no source_id given')
   if (!creator_id) throw new Error(subject_id + ': no creatord_id given')
@@ -20,6 +25,13 @@ Statement.builder = (subject_id, creator_id, base_source_hash) => {
   return new function () {
     this.statements = []
 
+    /**
+     *  For adding a single statmement
+     *
+     *  @example
+     *  // This sets title 0 for subject 's1', recording the source marc "path":
+     *  builder.add('dcterms:title', { literal: 'Title of obj' }, 0, { path: '245 $a $b' })
+     */
     this.add = (predicate, object, index, source_hash) => {
       source_hash = Object.assign({}, base_source_hash, source_hash)
 
@@ -36,10 +48,59 @@ Statement.builder = (subject_id, creator_id, base_source_hash) => {
       if (!object || (!object.id && !object.literal && object.type !== 'xsd:boolean')) throw new Error(subject_id + ' > ' + predicate + ': invalid object: ' + JSON.stringify(object, null, 2))
       if (!source_hash || !source_hash.record_id) throw new Error(predicate + ': no record_id given')
 
-      this.addStatement(subject_id, predicate, object, index, source_hash)
+      this._addStatement(subject_id, predicate, object, index, source_hash)
     }
 
-    this.addStatement = (subject_id, predicate, object, index, source_hash) => {
+    /**
+     *  For adding a blank node.
+     *
+     *  Blank nodes are implemented as:
+     *   - one statement linking the primary subject to the blank node by id
+     *   - any number of statements about the blank node itself
+     *
+     *  Blank node ids are built using: [primary subject id]#[creator id].[padded index]
+     *
+     *  @example
+     *  // This adds a blank node for subject 's1' representing a Note.
+     *  let blankNode = {
+     *    'rdfs:type': { id: 'bf:Note' },
+     *    'bf:noteType': { literal: 'General Note' },
+     *    'rdfs:label': { literal: 'American Masters, Thirteen/WNET.' }
+     *  }
+     *  builder.addBlankNode('skos:note', blankNode, 0, { path: '500 $a'})
+     *
+     *  For primary subject 's1', the records generated above might be:
+     *   - subject_id: 's1', predicate: 'skos:note', object_id: 's1#1.0000', ...
+     *   - subject_id: 's1#1.0000', predicate: 'rdfs:type', object_id: 'bf:Note', ...
+     *   - subject_id: 's1#1.0000', predicate: 'bf:noteType', object_literal: 'General Note', ...
+     *   - subject_id: 's1#1.0000', predicate: 'rdfs:label', object_literal: 'American Masters, Thirteen/WNET.', ...
+     */
+    this.addBlankNode = (predicate, blankNode, index, source_hash) => {
+      source_hash = Object.assign({}, base_source_hash, source_hash)
+
+      // Generate locally unique id
+      const suffix = utils.lpad(String(blankNodeCount), 4, '0')
+      const blankNodeId = `${subject_id}#${creator_id}.${suffix}`
+
+      // Link main record to blank node:
+      this.add(predicate, { id: blankNodeId }, index, source_hash)
+
+      Object.keys(blankNode).forEach((predicate) => {
+        // Add blank node statements:
+        this._addStatement(blankNodeId, predicate, blankNode[predicate], index, source_hash)
+      })
+
+      blankNodeCount += 1
+    }
+
+    /**
+     *  For adding a single statmement (internal use)
+     *
+     *  @example
+     *  // This sets title 0 for subject 's1':
+     *  builder._addStatement('s1', 'dcterms:title', { literal: 'Title of obj' }, 0, { id: 'sourcedbid', record_id: 'sourcerecordid' })
+     */
+    this._addStatement = (subject_id, predicate, object, index, source_hash) => {
       var props = {
         subject_id,
         predicate,
@@ -56,24 +117,6 @@ Statement.builder = (subject_id, creator_id, base_source_hash) => {
 
       var statement = new Statement(props)
       this.statements.push(statement)
-    }
-
-    this.addBlankNode = (predicate, blankNode, index, source_hash) => {
-      source_hash = Object.assign({}, base_source_hash, source_hash)
-
-      // Generate locally unique id
-      const suffix = utils.lpad(String(blankNodeCount), 4, '0')
-      const blankNodeId = `${subject_id}#${creator_id}.${suffix}`
-
-      // Link main record to blank node:
-      this.add(predicate, { id: blankNodeId }, index, source_hash)
-
-      Object.keys(blankNode).forEach((predicate) => {
-        // Add blank node statements:
-        this.addStatement(blankNodeId, predicate, blankNode[predicate], index, source_hash)
-      })
-
-      blankNodeCount += 1
     }
 
     this.getAll = (pred) => this.statements.filter((s) => s.predicate === pred)

--- a/lib/models/statement.js
+++ b/lib/models/statement.js
@@ -1,4 +1,4 @@
-'use strict'
+const utils = require('../utils')
 
 class Statement {
   constructor (props) {
@@ -14,6 +14,8 @@ class Statement {
 Statement.builder = (subject_id, creator_id, base_source_hash) => {
   if (!base_source_hash.id) throw new Error(subject_id + ': no source_id given')
   if (!creator_id) throw new Error(subject_id + ': no creatord_id given')
+
+  let blankNodeCount = 0
 
   return new function () {
     this.statements = []
@@ -34,6 +36,10 @@ Statement.builder = (subject_id, creator_id, base_source_hash) => {
       if (!object || (!object.id && !object.literal && object.type !== 'xsd:boolean')) throw new Error(subject_id + ' > ' + predicate + ': invalid object: ' + JSON.stringify(object, null, 2))
       if (!source_hash || !source_hash.record_id) throw new Error(predicate + ': no record_id given')
 
+      this.addStatement(subject_id, predicate, object, index, source_hash)
+    }
+
+    this.addStatement = (subject_id, predicate, object, index, source_hash) => {
       var props = {
         subject_id,
         predicate,
@@ -50,6 +56,24 @@ Statement.builder = (subject_id, creator_id, base_source_hash) => {
 
       var statement = new Statement(props)
       this.statements.push(statement)
+    }
+
+    this.addBlankNode = (predicate, blankNode, index, source_hash) => {
+      source_hash = Object.assign({}, base_source_hash, source_hash)
+
+      // Generate locally unique id
+      const suffix = utils.lpad(String(blankNodeCount), 4, '0')
+      const blankNodeId = `${subject_id}#${creator_id}.${suffix}`
+
+      // Link main record to blank node:
+      this.add(predicate, { id: blankNodeId }, index, source_hash)
+
+      Object.keys(blankNode).forEach((predicate) => {
+        // Add blank node statements:
+        this.addStatement(blankNodeId, predicate, blankNode[predicate], index, source_hash)
+      })
+
+      blankNodeCount += 1
     }
 
     this.getAll = (pred) => this.statements.filter((s) => s.predicate === pred)

--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -223,7 +223,7 @@ var fromMarcJson = (object, datasource) => {
       val.forEach((v) => {
         // Build a "Note" blank node with three statements:
         let blankNode = {
-          'rdfs:type': { id: 'bf:Note' },
+          'rdf:type': { id: 'bf:Note' },
           'bf:noteType': { literal: path.description },
           'rdfs:label': { literal: v }
         }

--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -221,14 +221,12 @@ var fromMarcJson = (object, datasource) => {
 
       // Save one statement per value found:
       val.forEach((v) => {
-        // builder.add(noteMapping.pred, { literal: v, label: path.description }, index, { path: recordPath })
-        // TODO something like this: ...
+        // Build a "Note" blank node with three statements:
         let blankNode = {
           'rdfs:type': { id: 'bf:Note' },
           'bf:noteType': { literal: path.description },
           'rdfs:label': { literal: v }
         }
-
         builder.addBlankNode(noteMapping.pred, blankNode, index, { path: recordPath })
         index += 1
       })

--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -152,6 +152,7 @@ var fromMarcJson = (object, datasource) => {
     // Parse a bunch of straightforwardly mapped literals:
     ; [
       'Alternative title',
+      'Contents',
       'Contributor literal',
       'Creator literal',
       'Description',
@@ -220,7 +221,15 @@ var fromMarcJson = (object, datasource) => {
 
       // Save one statement per value found:
       val.forEach((v) => {
-        builder.add(noteMapping.pred, { literal: v, label: path.description }, index, { path: recordPath })
+        // builder.add(noteMapping.pred, { literal: v, label: path.description }, index, { path: recordPath })
+        // TODO something like this: ...
+        let blankNode = {
+          'rdfs:type': { id: 'bf:Note' },
+          'bf:noteType': { literal: path.description },
+          'rdfs:label': { literal: v }
+        }
+
+        builder.addBlankNode(noteMapping.pred, blankNode, index, { path: recordPath })
         index += 1
       })
     })

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -393,13 +393,13 @@ describe('Bib Marc Mapping', function () {
           //  * 'Purchased from the Carl B. and Marjorie N. Boyer Fund' (541 $a with ind1 '0', so suppress)
 
           // There is one note in 505 $a
-          assert.equal(bib.blankNodes('skos:note')[0].literal('rdfs:label'), 'Translation of La vie quotidienne dans l\'Empire carolingien.')
+          assert.equal(bib.blankNodes('bf:note')[0].literal('rdfs:label'), 'Translation of La vie quotidienne dans l\'Empire carolingien.')
 
           // Another note in 504 $a:
-          assert.equal(bib.blankNodes('skos:note')[1].literal('rdfs:label'), 'Includes bibliographical references and index.')
+          assert.equal(bib.blankNodes('bf:note')[1].literal('rdfs:label'), 'Includes bibliographical references and index.')
 
           // There's another note in 541 but ind1 === '0', so above should be all we get:
-          assert.equal(bib.blankNodes('skos:note').length, 2)
+          assert.equal(bib.blankNodes('bf:note').length, 2)
         })
     })
 
@@ -411,7 +411,7 @@ describe('Bib Marc Mapping', function () {
         .then((bib) => {
           // This bib has one note in 505, but ind1 === 0, so it should be suppressed
           // which means it has NO notes.
-          assert.equal(bib.literals('skos:note').length, 0)
+          assert.equal(bib.literals('bf:note').length, 0)
         })
     })
 
@@ -625,14 +625,14 @@ describe('Bib Marc Mapping', function () {
       return bibSerializer.fromMarcJson(bib)
         .then((statements) => new Bib(statements))
         .then((bib) => {
-          assert.equal(bib.statements('skos:note').length, 9)
+          assert.equal(bib.statements('bf:note').length, 9)
 
           // Among those 9 notes, grab the one with noteType "Immediate Source of Acquisition Note":
-          let blankNode = bib.blankNodes('skos:note')
+          let blankNode = bib.blankNodes('bf:note')
             .filter((node) => node.literal('bf:noteType') === 'Immediate Source of Acquisition Note')
             .pop()
           assert.equal(blankNode.statements().length, 3)
-          assert.equal(blankNode.objectId('rdfs:type'), 'bf:Note')
+          assert.equal(blankNode.objectId('rdf:type'), 'bf:Note')
           assert.equal(blankNode.literal('bf:noteType'), 'Immediate Source of Acquisition Note')
           assert.equal(blankNode.literal('rdfs:label'), 'American Masters, Thirteen/WNET.')
         })

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -82,8 +82,6 @@ describe('Bib Marc Mapping', function () {
       return bibSerializer.fromMarcJson(bib)
         .then((statements) => new Bib(statements))
         .then((bib) => {
-          // console.log('bib: ', bib)
-
           assert.equal(bib.objectId('rdfs:type'), 'nypl:Item')
           assert.equal(bib.objectId('dcterms:type'), 'resourcetypes:txt')
 
@@ -150,7 +148,6 @@ describe('Bib Marc Mapping', function () {
       return bibSerializer.fromMarcJson(bib)
         .then((statements) => new Bib(statements))
         .then((bib) => {
-          // console.log('contribs: ', JSON.stringify(bib.statements('dc:contributor'), null, 2))
           // Note this is the pred for contributorLiteral:
           assert.equal(bib.literal('dc:contributor'), 'International Society for the Study of Behavioral Development.')
         })
@@ -396,13 +393,13 @@ describe('Bib Marc Mapping', function () {
           //  * 'Purchased from the Carl B. and Marjorie N. Boyer Fund' (541 $a with ind1 '0', so suppress)
 
           // There is one note in 505 $a
-          assert.equal(bib.literal('skos:note'), 'Translation of La vie quotidienne dans l\'Empire carolingien.')
+          assert.equal(bib.blankNodes('skos:note')[0].literal('rdfs:label'), 'Translation of La vie quotidienne dans l\'Empire carolingien.')
 
           // Another note in 504 $a:
-          assert.equal(bib.literals('skos:note')[1], 'Includes bibliographical references and index.')
+          assert.equal(bib.blankNodes('skos:note')[1].literal('rdfs:label'), 'Includes bibliographical references and index.')
 
           // There's another note in 541 but ind1 === '0', so above should be all we get:
-          assert.equal(bib.literals('skos:note').length, 2)
+          assert.equal(bib.blankNodes('skos:note').length, 2)
         })
     })
 
@@ -619,6 +616,35 @@ describe('Bib Marc Mapping', function () {
           let subjects = bib.literals('dc:subject')
           let graphicNovelSubject = subjects.filter((subject) => subject === 'Graphic novels.')
           assert.equal(graphicNovelSubject.length, 0)
+        })
+    })
+
+    it('should parse Notes blank nodes correctly', function () {
+      var bib = BibSierraRecord.from(require('./data/bib-18064236.json'))
+
+      return bibSerializer.fromMarcJson(bib)
+        .then((statements) => new Bib(statements))
+        .then((bib) => {
+          assert.equal(bib.statements('skos:note').length, 9)
+
+          // Among those 9 notes, grab the one with noteType "Immediate Source of Acquisition Note":
+          let blankNode = bib.blankNodes('skos:note')
+            .filter((node) => node.literal('bf:noteType') === 'Immediate Source of Acquisition Note')
+            .pop()
+          assert.equal(blankNode.statements().length, 3)
+          assert.equal(blankNode.objectId('rdfs:type'), 'bf:Note')
+          assert.equal(blankNode.literal('bf:noteType'), 'Immediate Source of Acquisition Note')
+          assert.equal(blankNode.literal('rdfs:label'), 'American Masters, Thirteen/WNET.')
+        })
+    })
+
+    it('should parse Contents (dcterms:tableOfContents) correctly', function () {
+      var bib = BibSierraRecord.from(require('./data/bib-18064236.json'))
+
+      return bibSerializer.fromMarcJson(bib)
+        .then((statements) => new Bib(statements))
+        .then((bib) => {
+          assert.equal(bib.literal('dcterms:tableOfContents'), 'Jerome Rabinowitz -- Life-changing revelations -- Camp Tamiment -- Ballet Theatre -- Fancy free -- On the town -- The playful side and the darker side -- Love and loss -- Autobiographical material -- Broadway\'s rising star -- Balanchine and the New York City Ballet -- The king and I -- The House Un-American Activities Committee -- Robbins\' muse, Tanaquil Le Clercq -- Peter Pan -- West side story -- Ballets U.S.A. -- Gypsy -- Challenges and fixes -- Fiddler on the roof -- Les noces -- Dances at a gathering -- The Goldberg variations -- Watermill -- Robbins and Balanchine -- Dybbuk -- Other dances -- Glass pieces and Antique epigraphs -- In memory of... -- Jerome Robbins\' Broadway -- Dancing until the end.')
         })
     })
   })


### PR DESCRIPTION
This PR adds blank node support to the DiscoveryStorePoster.

Previously one added statements solely by calling something like this:

```
const builder = Statement.builder(...)
builder.add('skos:note', { literal: 'American Masters, Thirteen/WNET.' }, ...)
```
The generated statement is singular and flat, with no clean ability to store additional information like `bf:noteType`.

This implementation adds a new statement builder hook one can use like this:

```
// This adds a blank node for subject 's1' representing a Note.
let blankNode = {
  'rdfs:type': { id: 'bf:Note' },
  'bf:noteType': { literal: 'General Note' },
  'rdfs:label': { literal: 'American Masters, Thirteen/WNET.' }
}
builder.addBlankNode('skos:note', blankNode, 0, { path: '500 $a'})
```
The above will generate four distinct statements. If primary subject id is 's1', the records generated might be:
 - subject_id: 's1', predicate: 'skos:note', object_id: 's1#1.0000', ...
 - subject_id: 's1#1.0000', predicate: 'rdfs:type', object_id: 'bf:Note', ...
 - subject_id: 's1#1.0000', predicate: 'bf:noteType', object_literal: 'General Note', ...
 - subject_id: 's1#1.0000', predicate: 'rdfs:label', object_literal: 'American Masters, Thirteen/WNET.', ...
