### PR TITLE
Add serialization of publicationStatement

### DIFF
--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -154,6 +154,7 @@ var fromMarcJson = (object, datasource) => {
       'Extent',
       'LCC classification',
       'Place of publication',
+      'Publication statement',
       'Publisher literal',
       'Series statement',
       'Title',

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -675,5 +675,15 @@ describe('Bib Marc Mapping', function () {
           assert.equal(bib.literal('dcterms:tableOfContents'), 'Jerome Rabinowitz -- Life-changing revelations -- Camp Tamiment -- Ballet Theatre -- Fancy free -- On the town -- The playful side and the darker side -- Love and loss -- Autobiographical material -- Broadway\'s rising star -- Balanchine and the New York City Ballet -- The king and I -- The House Un-American Activities Committee -- Robbins\' muse, Tanaquil Le Clercq -- Peter Pan -- West side story -- Ballets U.S.A. -- Gypsy -- Challenges and fixes -- Fiddler on the roof -- Les noces -- Dances at a gathering -- The Goldberg variations -- Watermill -- Robbins and Balanchine -- Dybbuk -- Other dances -- Glass pieces and Antique epigraphs -- In memory of... -- Jerome Robbins\' Broadway -- Dancing until the end.')
         })
     })
+
+    it('should parse publicationStatement correctly', function () {
+      var bib = BibSierraRecord.from(require('./data/bib-20972964.json'))
+
+      return bibSerializer.fromMarcJson(bib)
+        .then((statements) => new Bib(statements))
+        .then((bib) => {
+          assert.equal(bib.literal('nypl:publicationStatement'), '[Chilpancingo de los Bravo, México] : Guerrero, Gobierno del Estado Libre y Soberano, Secretaría de Cultura ; México, D.F. : CONACULTA : Editorial Praxis, 2015.')
+        })
+    })
   })
 })


### PR DESCRIPTION
Adds extraction of bib publicationStatement (260 & 264 a,b,c)

DEPENDS on updated mapping in https://github.com/NYPL/nypl-core/tree/pb/publication-statement