### PR TITLE
Add patch to truncate source_record_path to 50

### DIFF
--- a/lib/models/statement.js
+++ b/lib/models/statement.js
@@ -109,11 +109,14 @@ Statement.builder = (subject_id, creator_id, base_source_hash) => {
         creator_id,
         index
       }
+
       if (object.id) props.object_id = object.id
       if (object.label) props.object_label = object.label
       if (object.literal || object.type === 'xsd:boolean') props.object_literal = object.literal
       if (object.type) props.object_type = object.type
-      if (source_hash.path) props.source_record_path = source_hash.path
+      // Should come up with a more compact representation, perhaps, because
+      // we have to truncate in some cases:
+      if (source_hash.path) props.source_record_path = utils.truncate(source_hash.path, 50, '..')
 
       var statement = new Statement(props)
       this.statements.push(statement)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -98,6 +98,11 @@ const compact = (a) => {
   return a.filter((i) => i)
 }
 
+const truncate = (s, len, indicator = '...') => {
+  if (s.length <= len) return s
+  else return s.substring(0, len - indicator.length) + indicator
+}
+
 /**
  * Returns the first matching entity in the given mapping hash that has a matching `code`
  * For use with nypl-core-objects mappings
@@ -116,4 +121,4 @@ const coreObjectsMappingByCode = (mapping, code) => {
     .shift()
 }
 
-module.exports = { readJson, capitalize, writeFile, flattenArray, lpad, lineCount, compact, groupBy, coreObjectsMappingByCode }
+module.exports = { readJson, capitalize, writeFile, flattenArray, lpad, lineCount, compact, groupBy, coreObjectsMappingByCode, truncate }


### PR DESCRIPTION
Addresses issue surfaced by new mapping where some source_record_path
values exceed column width of 50. This patch simply truncates the value
with an ellipses in lieu of developing a more compact representation
guaranteed to fit in the 50-width column.