### PR TITLE
Change serialization of identifier types

### DIFF
--- a/lib/serializers/bib.js
+++ b/lib/serializers/bib.js
@@ -5,6 +5,7 @@ const Datasource = require('../models/datasource')
 const Lookup = require('../lookup')
 const buildFieldMapper = require('../field-mapper')
 const formattingUtils = require('./formatting-utils')
+const utils = require('../utils')
 const sierraLocationMapping = require('@nypl/nypl-core-objects')('by-sierra-location')
 
 function InvalidInputError (message) {
@@ -25,7 +26,7 @@ var fromMarcJson = (object, datasource) => {
     var builder = Statement.builder(id, Creator.CORE_SERIALIZER.id, { id: datasource.id, record_id: object.id })
 
     // Bnumber identifier
-    builder.add(fieldMapper.predicateFor('Identifier'), { id: `urn:bnum:${object.id}` }, 0, { path: 'id' })
+    builder.add(fieldMapper.predicateFor('Identifier'), { id: object.id, type: 'nypl:Bnumber' }, 0, { path: 'id' })
 
     // Title
     if (object.title) builder.add(fieldMapper.predicateFor('Title'), { literal: object.title }, 0, { path: 'title' })
@@ -218,9 +219,9 @@ var fromMarcJson = (object, datasource) => {
         if (path.subfields) recordPath += ' ' + path.subfields.map((s) => `$${s}`).join(' ')
 
         // Save one statement per value found:
-        val.forEach((v) => {
-          let namespace = name.toLowerCase()
-          builder.add(fieldMapping.pred, { id: `urn:${namespace}:${v}`, label: path.description }, null, { path: recordPath })
+        val.forEach((id) => {
+          const type = `bf:${utils.capitalize(name.toLowerCase())}`
+          builder.add(fieldMapping.pred, { id, type }, null, { path: recordPath })
         })
       })
     })

--- a/lib/serializers/item.js
+++ b/lib/serializers/item.js
@@ -131,7 +131,7 @@ var fromMarcJson = (object, datasource) => {
     var barcode = null
     if (object.barcode) barcode = { value: object.barcode, path: 'barcode' }
     else if (object.varField('876', ['p']).length) barcode = { value: object.varField('876', ['p'])[0], path: '876 $p' }
-    if (barcode) builder.add(fieldMapper.predicateFor('Identifier'), { id: `urn:barcode:${barcode.value}` }, 0, { path: barcode.path })
+    if (barcode) builder.add(fieldMapper.predicateFor('Identifier'), { id: barcode.value, type: 'bf:Barcode' }, 0, { path: barcode.path })
 
     // Callnum
     var callnum = null
@@ -184,7 +184,7 @@ var fromMarcJson = (object, datasource) => {
         : utils.coreObjectsMappingByCode(statusMapping, status.code)
       if (statusMapped) {
         let statusId = statusMapped.id.split(':').pop()
-        builder.add('bf:status', { id: `status:${statusId}`, label: statusMapped.label }, 0, { path: status.path })
+        builder.add('bf:status', { id: `status:${statusId}`, label: statusMapped.label.trim() }, 0, { path: status.path })
       } else console.error('could not find status for:', status)
     }
 

--- a/test/bib-marc-test.js
+++ b/test/bib-marc-test.js
@@ -225,8 +225,10 @@ describe('Bib Marc Mapping', function () {
       return bibSerializer.fromMarcJson(bib)
         .then((statements) => new Bib(statements))
         .then((bib) => {
-          assert.equal(bib.objectIds('dcterms:identifier')[0], 'urn:bnum:10392955')
-          assert.equal(bib.objectIds('dcterms:identifier')[1], 'urn:isbn:0192113860 :')
+          assert.equal(bib.objectIds('dcterms:identifier')[0], '10392955')
+          assert.equal(bib.statements('dcterms:identifier')[0].object_type, 'nypl:Bnumber')
+          assert.equal(bib.objectIds('dcterms:identifier')[1], '0192113860 :')
+          assert.equal(bib.statements('dcterms:identifier')[1].object_type, 'bf:Isbn')
         })
     })
 
@@ -236,8 +238,10 @@ describe('Bib Marc Mapping', function () {
       return bibSerializer.fromMarcJson(bib)
         .then((statements) => new Bib(statements))
         .then((bib) => {
-          assert.equal(bib.objectIds('dcterms:identifier')[0], 'urn:bnum:10011745')
-          assert.equal(bib.objectIds('dcterms:identifier')[1], 'urn:issn:0165-0254')
+          assert.equal(bib.statements('dcterms:identifier')[0].object_id, '10011745')
+          assert.equal(bib.statements('dcterms:identifier')[0].object_type, 'nypl:Bnumber')
+          assert.equal(bib.statements('dcterms:identifier')[1].object_id, '0165-0254')
+          assert.equal(bib.statements('dcterms:identifier')[1].object_type, 'bf:Issn')
         })
     })
 
@@ -492,7 +496,7 @@ describe('Bib Marc Mapping', function () {
           assert.equal(bib.objectId('bf:media'), 'mediatypes:n')
           assert.equal(bib.objectId('bf:carrier'), 'carriertypes:nc')
           // Extracted ISBN?
-          assert(bib.objectIds('dcterms:identifier').indexOf('urn:isbn:3871185949') >= 0)
+          assert(bib.statements('dcterms:identifier').filter((ident) => ident.object_id === '3871185949' && ident.object_type === 'bf:Isbn').length >= 0)
         })
     })
 
@@ -625,7 +629,7 @@ describe('Bib Marc Mapping', function () {
         .then((statements) => new Bib(statements))
         .then((bib) => {
           assert.equal(bib.id, 'b11070917')
-          assert(bib.objectIds('dcterms:identifier').indexOf('urn:lccn:r  59001818') >= 0)
+          assert(bib.statements('dcterms:identifier').filter((ident) => ident.object_id === 'r  59001818' && ident.object_type === 'bf:Lccn').length >= 0)
         })
     })
 


### PR DESCRIPTION
Changes the serialization of `identifier` statements to deprecate
practice of recording identifier type in a "urn" style (e.g.
"urn:issn:0165-0254") in favor of saving the plain id value without a
prefix (as object_id) and storing the type in object_type.

https://jira.nypl.org/browse/SRCH-100